### PR TITLE
Add generic OFX and PresidentChoice MasterCard importer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'django-allauth',
         'python-dateutil',
         'django-cors-headers',
+        'ofxparse',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/silverstrike/importers/__init__.py
+++ b/silverstrike/importers/__init__.py
@@ -1,4 +1,4 @@
-from . import dkb, dkb_visa, volksbank, pc_mastercard, ofx
+from . import dkb, dkb_visa, ofx, pc_mastercard, volksbank
 
 IMPORTERS = [
     pc_mastercard,

--- a/silverstrike/importers/__init__.py
+++ b/silverstrike/importers/__init__.py
@@ -1,12 +1,16 @@
-from . import dkb, dkb_visa, volksbank
+from . import dkb, dkb_visa, volksbank, pc_mastercard, ofx
 
 IMPORTERS = [
+    pc_mastercard,
+    ofx,
     dkb,
     dkb_visa,
     volksbank,
 ]
 
 IMPORTER_NAMES = [
+    'PC MasterCard',
+    'OFX Importer',
     'DKB Giro',
     'DKB Visa',
     'Volksbank',

--- a/silverstrike/importers/ofx.py
+++ b/silverstrike/importers/ofx.py
@@ -1,0 +1,35 @@
+
+from ofxparse import OfxParser
+
+from silverstrike.importers.import_statement import ImportStatement
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+DATE_FORMAT = "%m/%d/%Y"
+
+
+def import_csv(ofx_path):
+    transactions = []
+    with open(ofx_path, encoding='latin-1') as ofx_file:
+        logger.info("Opening ofx file %s", ofx_path)
+        try:
+            ofx = OfxParser.parse(ofx_file)
+            for transaction in ofx.account.statement.transactions:
+                try:
+                    transaction_time = transaction.date
+                    transactions.append(ImportStatement(
+                        notes=transaction.payee,
+                        book_date=transaction_time,
+                        transaction_date=transaction_time,
+                        amount=transaction.amount
+                        ))
+                except ValueError as e:
+                    logger.error("Cannot import transaction: {}".format(transaction))
+                    pass
+        except ValueError as fe:
+            logger.error("Failed to import all transactions! Wrong file format?")
+
+    return transactions
+

--- a/silverstrike/importers/ofx.py
+++ b/silverstrike/importers/ofx.py
@@ -1,9 +1,10 @@
 
+import logging
+
 from ofxparse import OfxParser
 
 from silverstrike.importers.import_statement import ImportStatement
 
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -25,11 +26,10 @@ def import_csv(ofx_path):
                         transaction_date=transaction_time,
                         amount=transaction.amount
                         ))
-                except ValueError as e:
+                except ValueError:
                     logger.error("Cannot import transaction: {}".format(transaction))
                     pass
-        except ValueError as fe:
+        except ValueError:
             logger.error("Failed to import all transactions! Wrong file format?")
 
     return transactions
-

--- a/silverstrike/importers/pc_mastercard.py
+++ b/silverstrike/importers/pc_mastercard.py
@@ -1,0 +1,32 @@
+import csv
+import datetime
+
+from silverstrike.importers.import_statement import ImportStatement
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def import_csv(csv_path):
+    lines = []
+    with open(csv_path, encoding='latin-1') as csv_file:
+        logger.info("Opened csv file %s", csv_path)
+        csviter = csv.reader(csv_file, delimiter=',')
+        next(csviter)  # First line is header
+        for line in csviter:
+            logger.info("Line %s", line)
+            try:
+                transaction_time = datetime.datetime.strptime(line[2] + ' ' + line[3], '%m/%d/%Y %I:%M %p')
+                lines.append(ImportStatement(
+                    notes=line[0],
+                    account=line[1],
+                    book_date=transaction_time,
+                    transaction_date=transaction_time,
+                    amount=-float(line[4])
+                    ))
+            except ValueError as e:
+                logger.error("Error" + e)
+                pass
+
+    return lines

--- a/silverstrike/importers/pc_mastercard.py
+++ b/silverstrike/importers/pc_mastercard.py
@@ -1,9 +1,9 @@
 import csv
 import datetime
+import logging
 
 from silverstrike.importers.import_statement import ImportStatement
 
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +17,8 @@ def import_csv(csv_path):
         for line in csviter:
             logger.info("Line %s", line)
             try:
-                transaction_time = datetime.datetime.strptime(line[2] + ' ' + line[3], '%m/%d/%Y %I:%M %p')
+                transaction_time = datetime.datetime.strptime(line[2] + ' ' + line[3],
+                                                              '%m/%d/%Y %I:%M %p')
                 lines.append(ImportStatement(
                     notes=line[0],
                     account=line[1],


### PR DESCRIPTION
Many major banks (at least in Canada) support downloading statements in OFX format.
This PR will add OFX importer for Silverstrike.
Note: 
- In order to use OFX importer 'ofxparse' package needs to be installed.
`$ pip install ofxparse`
- Import page has only CSV import button. Because import procedure for OFX is very similar, I think that button can be renamed to something more generic.

