### PR TITLE
Exclude account from current balance when show_on_dashboard=False

### DIFF
--- a/silverstrike/models.py
+++ b/silverstrike/models.py
@@ -182,6 +182,9 @@ class SplitQuerySet(models.QuerySet):
     def personal(self):
         return self.filter(account__account_type=Account.AccountType.PERSONAL)
 
+    def personal_dashboard(self):
+        return self.filter(account__account_type=Account.AccountType.PERSONAL, account__show_on_dashboard=True)
+
     def income(self):
         return self.filter(opposing_account__account_type=Account.AccountType.FOREIGN, amount__gt=0)
 

--- a/silverstrike/templates/silverstrike/charts.html
+++ b/silverstrike/templates/silverstrike/charts.html
@@ -21,6 +21,11 @@
     <button id="currentMonth" class="btn btn-s btn-default range-chooser">{% trans 'Current Month' %}</button>
     <!--button id="custom" class="btn btn-s btn-default range-chooser">Custom Range</button-->
   </div>
+  <div class="row text-right">
+      <span>
+      {% trans 'Include Non-dashboard Accounts' %} <input title="{% trans 'Include Non-dashboard Accounts' %}" type="checkbox" id="include_non_dashboard_accounts" class=""></input>
+      </span>&nbsp;
+  </div>
 </div>
 </div>
 <div class="row">
@@ -202,10 +207,46 @@ var one_month = 0;
 var three_months = 1;
 var six_months = 2;
 var twelve_months = 3;
+var current_chart_range = three_months;
 var accountChartData = new Array(4);
 var balanceChartData = new Array(4);
 var categoryChartData = new Array(4);
 
+function get_balance_data(url_data, callback) {
+  url = "";
+  if ($('#include_non_dashboard_accounts')[0].checked) {
+      switch (url_data) {
+          case one_month:
+              url = "{% url 'api_non_dashboard_balance' first_day_of_month last_day_of_month %}"
+              break;
+          case three_months:
+              url = "{% url 'api_non_dashboard_balance' minus_3_months today %}"
+              break;
+          case six_months:
+              url = "{% url 'api_non_dashboard_balance' minus_6_months today %}"
+              break;
+          case twelve_months:
+              url = "{% url 'api_non_dashboard_balance' minus_12_months today %}"
+              break;
+      }
+  } else {
+      switch (url_data) {
+          case one_month:
+              url = "{% url 'api_balance' first_day_of_month last_day_of_month %}"
+              break;
+          case three_months:
+              url = "{% url 'api_balance' minus_3_months today %}"
+              break;
+          case six_months:
+              url = "{% url 'api_balance' minus_6_months today %}"
+              break;
+          case twelve_months:
+              url = "{% url 'api_balance' minus_12_months today %}"
+              break;
+      }
+  }
+  $.getJSON(url, {}, function(res, status) { callback(res, status) });
+}
 
 // initialize
 $.getJSON("{% url 'api_accounts_balance' minus_3_months today %}", {}, function(res, status) {
@@ -223,7 +264,15 @@ $.getJSON("{% url 'category_spending' minus_3_months today %}", {}, function(res
 });
 
 // update charts
+$('#include_non_dashboard_accounts').click(function() {
+    get_balance_data(current_chart_range,  function(res, status) {
+        drawBalances(res);
+        balanceChartData[three_months] = res;
+    });
+});
+
 $('#12month').click(function() {
+  current_chart_range = twelve_months;
   if (accountChartData[twelve_months] == null) {
     $.getJSON("{% url 'api_accounts_balance' minus_12_months today %}", {}, function(res, status) {
       updateAccountChart(res);
@@ -233,7 +282,7 @@ $('#12month').click(function() {
       updateAccountChart(accountChartData[twelve_months]);
   }
   if (balanceChartData[twelve_months] == null) {
-    $.getJSON("{% url 'api_balance' minus_12_months today %}", {}, function(res, status) {
+    get_balance_data(twelve_months, function(res, status) {
       updateBalanceChart(res);
       balanceChartData[twelve_months] = res;
     });
@@ -252,6 +301,7 @@ $('#12month').click(function() {
 
 
 $('#6month').click(function() {
+  current_chart_range = six_months;
   if (accountChartData[six_months] == null) {
     $.getJSON("{% url 'api_accounts_balance' minus_6_months today %}", {}, function(res, status) {
       updateAccountChart(res);
@@ -262,7 +312,7 @@ $('#6month').click(function() {
   }
 
   if (balanceChartData[six_months] == null) {
-    $.getJSON("{% url 'api_balance' minus_6_months today %}", {}, function(res, status) {
+    get_balance_data(six_months, function(res, status) {
       updateBalanceChart(res);
       balanceChartData[six_months] = res;
     });
@@ -281,6 +331,7 @@ $('#6month').click(function() {
 });
 
 $('#3month').click(function() {
+  current_chart_range = three_months;
   updateAccountChart(accountChartData[three_months]);
   updateBalanceChart(balanceChartData[three_months]);
   updateCategoryChart(categoryChartData[three_months]);
@@ -288,6 +339,7 @@ $('#3month').click(function() {
 
 
 $('#currentMonth').click(function() {
+  current_chart_range = one_month;
   if (accountChartData[one_month] == null) {
     $.getJSON("{% url 'api_accounts_balance' first_day_of_month last_day_of_month %}", {}, function(res, status) {
       updateAccountChart(res);
@@ -298,7 +350,7 @@ $('#currentMonth').click(function() {
   }
 
   if (balanceChartData[one_month] == null) {
-    $.getJSON("{% url 'api_balance' first_day_of_month last_day_of_month %}", {}, function(res, status) {
+    get_balance_data(one_month, function(res, status) {
       updateBalanceChart(res);
       balanceChartData[one_month] = res;
     });

--- a/silverstrike/tests/views/test_IndexView.py
+++ b/silverstrike/tests/views/test_IndexView.py
@@ -13,7 +13,8 @@ class IndexViewTestCase(TestCase):
         User.objects.create_superuser(username='admin', email='email@example.com', password='pass')
         self.client.login(username='admin', password='pass')
         self.account = Account.objects.create(name='first account', show_on_dashboard=True)
-        self.personal = Account.objects.create(name='personal')
+        self.personal = Account.objects.create(name='personal', show_on_dashboard=True)
+        self.cash = Account.objects.create(name='cash', show_on_dashboard=False)
         self.foreign = Account.objects.create(
             name="foreign account", account_type=Account.AccountType.FOREIGN)
 
@@ -43,6 +44,14 @@ class IndexViewTestCase(TestCase):
                            Transaction.WITHDRAW, date(2100, 1, 1))
         context = self.client.get(reverse('index')).context
         self.assertEqual(context['balance'], 0)
+
+    def test_balance_does_not_count_non_dashboard_accounts(self):
+        create_transaction('meh', self.foreign, self.account, 1000,
+                           Transaction.DEPOSIT, date(2015, 1, 1))
+        create_transaction('meh', self.cash, self.foreign, 500,
+                           Transaction.DEPOSIT, date(2015, 1, 1))
+        context = self.client.get(reverse('index')).context
+        self.assertEqual(context['balance'], 1000)
 
     def test_income(self):
         pass

--- a/silverstrike/urls.py
+++ b/silverstrike/urls.py
@@ -114,6 +114,7 @@ urlpatterns = [
 
     path('api/accounts/<account_type>/', api.get_accounts, name='api_accounts'),
     path('api/balance/<dstart>/<dend>/', api.get_balances, name='api_balance'),
+    path('api/non_dashboard_balance/<dstart>/<dend>/', api.get_non_dashboard_balances, name='api_non_dashboard_balance'),
     path('api/account/<int:account_id>/balance/<dstart>/<dend>/',
          api.get_account_balance, name='api_account_balance'),
     path('api/accounts_balance/<dstart>/<dend>/',

--- a/silverstrike/views/index.py
+++ b/silverstrike/views/index.py
@@ -18,7 +18,7 @@ class IndexView(LoginRequiredMixin, generic.TemplateView):
         dend = last_day_of_month(dstart)
         context = super().get_context_data(**kwargs)
         context['menu'] = 'home'
-        queryset = Split.objects.personal().past()
+        queryset = Split.objects.personal_dashboard().past()
         context['balance'] = queryset.aggregate(
             models.Sum('amount'))['amount__sum'] or 0
         queryset = queryset.date_range(dstart, dend)


### PR DESCRIPTION
Resolves Issue #133 

* fixes `api/balance` to only show accounts with `show_on_dashboard=True`
* creates `api/balance` to show all accounts regardless of `show on dashboard`
* adds 'show all accounts' checkbox on charts page