### PR TITLE
Adding split tests and transaction validation

### DIFF
--- a/silverstrike/models/__init__.py
+++ b/silverstrike/models/__init__.py
@@ -6,3 +6,5 @@ from .category import Category
 from .budget import Budget
 from .imports import ImportFile
 from .account_type import AccountType
+
+from .errors import TransactionSplitSumValidationError, TransactionSplitConsistencyValidationError

--- a/silverstrike/models/__init__.py
+++ b/silverstrike/models/__init__.py
@@ -7,4 +7,7 @@ from .budget import Budget
 from .imports import ImportFile
 from .account_type import AccountType
 
-from .errors import TransactionSplitSumValidationError, TransactionSplitConsistencyValidationError
+from .errors import TransactionSplitSumValidationError, \
+    TransactionSplitConsistencyValidationError, \
+    TransactionSignValidationError, \
+    TransactionAccountTypeValidationError

--- a/silverstrike/models/errors.py
+++ b/silverstrike/models/errors.py
@@ -1,0 +1,12 @@
+from django.core.exceptions import ValidationError
+
+
+class TransactionSplitSumValidationError(ValidationError):
+    def __init__(self, account):
+        super().__init__(f"Can't validate splits for account:{account} are in balance")
+
+
+class TransactionSplitConsistencyValidationError(ValidationError):
+    def __init__(self, account):
+        super().__init__(f"Can't validate splits for account:{account} equal transaction amount")
+

--- a/silverstrike/models/errors.py
+++ b/silverstrike/models/errors.py
@@ -1,12 +1,25 @@
 from django.core.exceptions import ValidationError
 
 
+class TransactionSignValidationError(ValidationError):
+    def __init__(self):
+        super().__init__(f"Transaction amounts must be positive.")
+
+
+class TransactionAccountTypeValidationError(ValidationError):
+    def __init__(self, account_type, transaction_type, account_slot):
+        super().__init__(
+            f"Transaction account type {account_type} is not allowed in "
+            f"{transaction_type} transaction {account_slot}")
+
+
 class TransactionSplitSumValidationError(ValidationError):
     def __init__(self, account):
         super().__init__(f"Can't validate splits for account:{account} are in balance")
 
 
 class TransactionSplitConsistencyValidationError(ValidationError):
-    def __init__(self, account):
-        super().__init__(f"Can't validate splits for account:{account} equal transaction amount")
-
+    def __init__(self, account, account_amount, transaction_amount):
+        super().__init__(
+            f"Can't validate splits for account:{account} (${account_amount}) "
+            f"equal transaction amount (${transaction_amount})")

--- a/silverstrike/models/transaction.py
+++ b/silverstrike/models/transaction.py
@@ -112,7 +112,7 @@ class Transaction(models.Model):
             self.clean_transaction_amount()
         if 'transaction_type' not in exclude:
             self.clean_transaction_types()
-        if 'src' not in exclude:
+        if 'src' not in exclude and not self._state.adding:
             self.clean_amounts_per_transaction()
 
     def save(self, *args, **kwargs):

--- a/silverstrike/rest/serializers.py
+++ b/silverstrike/rest/serializers.py
@@ -42,7 +42,7 @@ class SplitSerializer(serializers.ModelSerializer):
 class TransactionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Transaction
-        required_fields = ('title', 'src', 'dst', 'date', 'transaction_type', 'splits')
+        required_fields = ('title', 'src', 'amount', 'dst', 'date', 'transaction_type', 'splits')
         read_only_fields = ('last_modified',)
         fields = ('id', *required_fields, *read_only_fields)
 

--- a/silverstrike/rest/serializers.py
+++ b/silverstrike/rest/serializers.py
@@ -42,15 +42,18 @@ class SplitSerializer(serializers.ModelSerializer):
 class TransactionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Transaction
-        fields = ('id', 'title', 'date', 'transaction_type', 'splits', 'last_modified')
+        required_fields = ('title', 'src', 'dst', 'date', 'transaction_type', 'splits')
         read_only_fields = ('last_modified',)
+        fields = ('id', *required_fields, *read_only_fields)
 
     splits = SplitSerializer(many=True)
 
     def validate(self, data):
-        split_sum = sum([split['amount'] for split in data['splits']])
-        if split_sum != 0:
-            raise serializers.ValidationError("The sum of splits does not balance")
+        # most of the validation will be done during create
+        for field in TransactionSerializer.Meta.required_fields:
+            if data.get(field) is None:
+                raise serializers.ValidationError(
+                    f"Not all fields are specified. Missing field {field}")
         return data
 
     def create(self, validated_data):
@@ -59,6 +62,8 @@ class TransactionSerializer(serializers.ModelSerializer):
 
         for split in split_data:
             Split.objects.create(transaction=transaction, **split)
+
+        transaction.full_clean()
         return transaction
 
     def update(self, instance, validated_data):

--- a/silverstrike/tests/__init__.py
+++ b/silverstrike/tests/__init__.py
@@ -11,6 +11,25 @@ def create_transaction(title, src, dst, amount, type, date=date.today(), categor
               amount=-amount, transaction=t, date=date, category=category),
         Split(title=title, account=dst, opposing_account=src,
               amount=amount, transaction=t, date=date, category=category)])
+    t.save()
+    return t
+
+def create_transaction_without_split(title, src, dst, amount, type, date=date.today(), category=None):
+    t = Transaction.objects.create(title=title, date=date, transaction_type=type,
+                                   src=src, dst=dst, amount=amount)
+    t.save()
+    return t
+
+def create_transaction_with_splits(title, src, dst, amount, type, splits, date=date.today(), category=None):
+    t = Transaction.objects.create(title=title, date=date, transaction_type=type,
+                                   src=src, dst=dst, amount=amount)
+
+    for s in splits:
+        s.transaction = t
+
+    Split.objects.bulk_create(splits)
+
+    t.save()
     return t
 
 

--- a/silverstrike/tests/models/test_splits.py
+++ b/silverstrike/tests/models/test_splits.py
@@ -108,8 +108,11 @@ class SplitModelTests(TestCase):
             account_type=AccountType.FOREIGN)
 
     def test_split_str_method(self):
-        transaction = create_transaction('meh', self.foreign, self.personal,
-                                         100, Transaction.DEPOSIT)
+        transaction = create_transaction('meh',
+                                         src=self.foreign,
+                                         dst=self.personal,
+                                         amount=100,
+                                         type=Transaction.DEPOSIT)
         split = transaction.splits.first()
         self.assertEqual(str(split), split.title)
 
@@ -120,50 +123,129 @@ class SplitModelTests(TestCase):
         self.assertEqual(split.get_absolute_url(), reverse('transaction_detail',
                                                            args=[split.transaction.id]))
 
+
+class SplitValidationTests(TestCase):
+    def setUp(self):
+        self.personal = Account.objects.create(name='personal')
+        self.savings = Account.objects.create(name='savings')
+        self.foreign = Account.objects.create(
+            name='foreign',
+            account_type=AccountType.FOREIGN)
+
     def test_split_raises_validation_error_for_unbalanced_sum(self):
         unbalanced_split = [
-            Split(title="meh split 1", account=self.personal, opposing_account=self.foreign,
-                  amount=-50, date=date.today()),
-            Split(title="meh split 2", account=self.foreign, opposing_account=self.personal,
-                  amount=60, date=date.today())
+            Split(title="meh split 1",
+                  account=self.personal,
+                  opposing_account=self.foreign,
+                  amount=-50,
+                  date=date.today()),
+            Split(title="meh split 2",
+                  account=self.foreign,
+                  opposing_account=self.personal,
+                  amount=70,
+                  date=date.today())
         ]
 
         with self.assertRaises(ValidationError,
                                msg="create transaction with splits should validate "
                                    "transaction is in balance") as error:
-            create_transaction_with_splits('meh', self.foreign, self.personal, -70,
+            create_transaction_with_splits('meh',
+                                           self.personal,
+                                           self.foreign,
+                                           70,
                                            Transaction.WITHDRAW,
                                            unbalanced_split)
-        assert TransactionSplitSumValidationError(self.personal).message in error.exception.messages
+        self.assert_split_sum_error(error, self.personal)
 
     def test_split_validates_amount_sum(self):
         balanced_split = [
             Split(title="meh split 1", account=self.personal, opposing_account=self.foreign,
-                  amount=50, date=date.today()),
+                  amount=-50, date=date.today()),
             Split(title="meh split 2", account=self.foreign, opposing_account=self.personal,
-                  amount=-25, date=date.today()),
+                  amount=25, date=date.today()),
             Split(title="meh split 3", account=self.foreign, opposing_account=self.personal,
-                  amount=-25, date=date.today()),
+                  amount=25, date=date.today()),
         ]
 
-        create_transaction_with_splits('meh', self.personal, self.foreign, -50,
+        create_transaction_with_splits('meh', self.personal, self.foreign, 50,
                                        Transaction.WITHDRAW,
                                        balanced_split)
+
+    def test_transaction_validates_split_sum_is_correct_sign_withdraw(self):
+        balanced_split = [
+            Split(title="meh split 1", account=self.personal, opposing_account=self.foreign,
+                  amount=50, date=date.today()),
+            Split(title="meh split 1", account=self.foreign, opposing_account=self.personal,
+                  amount=-50, date=date.today()),
+        ]
+
+        with self.assertRaises(ValidationError,
+                               msg="create transaction with splits should validate "
+                                   "transaction consistent with split") as error:
+            create_transaction_with_splits('meh', self.personal, self.foreign, 50,
+                                           Transaction.WITHDRAW,
+                                           balanced_split)
+        self.assertIn(TransactionSplitConsistencyValidationError(
+            self.personal, "-50.00", 50).message, error.exception.messages)
+
+    def test_transaction_validates_split_sum_is_correct_sign_deposit(self):
+        balanced_split = [
+            Split(title="meh split 1", account=self.personal, opposing_account=self.foreign,
+                  amount=-50, date=date.today()),
+            Split(title="meh split 2", account=self.foreign, opposing_account=self.personal,
+                  amount=50, date=date.today()),
+        ]
+
+        with self.assertRaises(ValidationError,
+                               msg="create transaction with splits should validate "
+                                   "transaction consistent with split") as error:
+            create_transaction_with_splits('meh',
+                                           src=self.foreign,
+                                           dst=self.personal,
+                                           amount=50,
+                                           type=Transaction.DEPOSIT,
+                                           splits=balanced_split)
+        self.assertIn(TransactionSplitConsistencyValidationError(
+            self.foreign, "-50.00", 50).message, error.exception.messages)
+
+    def test_transaction_validates_split_sum_is_correct_sign_transfer(self):
+        balanced_split = [
+            Split(title="meh split 1", account=self.personal, opposing_account=self.savings,
+                  amount=-50, date=date.today()),
+            Split(title="meh split 2", account=self.savings, opposing_account=self.personal,
+                  amount=50, date=date.today()),
+        ]
+
+        with self.assertRaises(ValidationError,
+                               msg="create transaction with splits should validate "
+                                   "transaction consistent with split") as error:
+            create_transaction_with_splits('meh',
+                                           src=self.savings,
+                                           dst=self.personal,
+                                           amount=50,
+                                           type=Transaction.TRANSFER,
+                                           splits=balanced_split)
+        self.assertIn(TransactionSplitConsistencyValidationError(
+            self.savings, "-50.00", 50).message, error.exception.messages)
 
     def test_transaction_validates_split_sum_is_transaction_amount(self):
         balanced_split = [
             Split(title="meh split 1", account=self.personal, opposing_account=self.foreign,
-                  amount=50, date=date.today()),
+                  amount=-50, date=date.today()),
             Split(title="meh split 2", account=self.foreign, opposing_account=self.personal,
-                  amount=-25, date=date.today()),
+                  amount=25, date=date.today()),
             Split(title="meh split 3", account=self.foreign, opposing_account=self.personal,
-                  amount=-25, date=date.today()),
+                  amount=25, date=date.today()),
         ]
 
-        with self.assertRaises(TransactionSplitConsistencyValidationError,
+        with self.assertRaises(ValidationError,
                                msg="create transaction with splits should validate "
                                    "transaction consistent with split") as error:
-            create_transaction_with_splits('meh', self.personal, self.foreign, -70,
+            create_transaction_with_splits('meh', self.personal, self.foreign, 70,
                                            Transaction.WITHDRAW,
-                                       balanced_split)
-        assert TransactionSplitConsistencyValidationError(self.personal).message in error.exception.messages
+                                           balanced_split)
+        self.assertIn(TransactionSplitConsistencyValidationError(
+            self.personal, "50.00", 70).message, error.exception.messages)
+
+    def assert_split_sum_error(self, error, account):
+        self.assertIn(TransactionSplitSumValidationError(account).message, error.exception.messages)

--- a/silverstrike/tests/models/test_transactions.py
+++ b/silverstrike/tests/models/test_transactions.py
@@ -1,9 +1,12 @@
 from datetime import date
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.urls import reverse
 
 from silverstrike.models import Account, AccountType, Transaction
+from silverstrike.models import TransactionAccountTypeValidationError, \
+    TransactionSignValidationError
 from silverstrike.tests import create_transaction
 
 
@@ -28,6 +31,89 @@ class TransactionQuerySetTests(TestCase):
         create_transaction('meh', self.foreign, self.personal, 50, Transaction.DEPOSIT,
                            date=date(2018, 1, 1))
         self.assertEqual(Transaction.objects.last_10().count(), 1)
+
+
+class TransactionValidationTests(TestCase):
+    def setUp(self):
+        self.personal = Account.objects.create(name='personal')
+        self.savings = Account.objects.create(name='savings')
+        self.foreign = Account.objects.create(
+            name='foreign',
+            account_type=AccountType.FOREIGN)
+
+    def assert_account_type_error_message(self, error, account, transaction_type, account_slot):
+        self.assertIn(
+            TransactionAccountTypeValidationError(account.account_type_str, transaction_type, account_slot).message,
+            error.exception.messages)
+
+    def test_creating_transactions_deposit_source_requires_correct_account_types(self):
+        wrong_account = self.personal
+        with self.assertRaises(ValidationError,
+                               msg="create deposit transaction with incorrect accounts results in errors") as error:
+            create_transaction('meh', wrong_account, self.personal, 50, Transaction.DEPOSIT,
+                               date=date(2018, 1, 1))
+        self.assert_account_type_error_message(error, wrong_account, "Deposit", "source")
+
+    def test_creating_transactions_deposit_destination_requires_correct_account_types(self):
+        wrong_account = self.foreign
+        with self.assertRaises(ValidationError,
+                               msg="create deposit transaction with incorrect accounts results in errors") as error:
+            create_transaction('meh', self.foreign, wrong_account, 50, Transaction.DEPOSIT,
+                               date=date(2018, 1, 1))
+        self.assert_account_type_error_message(error, wrong_account, "Deposit", "destination")
+
+    def test_creating_transactions_withdraw_source_requires_correct_account_types(self):
+        wrong_account = self.foreign
+        with self.assertRaises(ValidationError,
+                               msg="create withdraw transaction with incorrect accounts results in errors") as error:
+            create_transaction('meh', wrong_account, self.foreign, 50, Transaction.WITHDRAW,
+                               date=date(2018, 1, 1))
+        self.assert_account_type_error_message(error, wrong_account, "Withdraw", "source")
+
+    def test_creating_transactions_withdraw_destination_requires_correct_account_types(self):
+        wrong_account = self.personal
+        with self.assertRaises(ValidationError,
+                               msg="create withdraw transaction with incorrect accounts results in errors") as error:
+            create_transaction('meh', self.personal, wrong_account, 50, Transaction.WITHDRAW,
+                               date=date(2018, 1, 1))
+        self.assert_account_type_error_message(error, wrong_account, "Withdraw", "destination")
+
+    def test_creating_transactions_transfer_source_requires_correct_account_types(self):
+        wrong_account = self.foreign
+        with self.assertRaises(ValidationError,
+                               msg="create transfer transaction with incorrect accounts results in errors") as error:
+            create_transaction('meh', wrong_account, self.personal, 50, Transaction.TRANSFER,
+                               date=date(2018, 1, 1))
+        self.assert_account_type_error_message(error, wrong_account, "Transfer", "source")
+
+    def test_creating_transactions_transfer_destination_requires_correct_account_types(self):
+        wrong_account = self.foreign
+        with self.assertRaises(ValidationError,
+                               msg="create withdraw transaction with incorrect accounts results in errors") as error:
+            create_transaction('meh', self.personal, wrong_account, 50, Transaction.TRANSFER,
+                               date=date(2018, 1, 1))
+        self.assert_account_type_error_message(error, wrong_account, "Transfer", "destination")
+
+    def test_creating_transactions_requires_positive_amounts_deposit(self):
+        with self.assertRaises(ValidationError,
+                               msg="create transaction with negative amounts results in errors") as error:
+            create_transaction('meh', self.foreign, self.personal, -50, Transaction.DEPOSIT,
+                               date=date(2018, 1, 1))
+        self.assertIn(TransactionSignValidationError().message, error.exception.messages)
+
+    def test_creating_transactions_requires_positive_amounts_withdraw(self):
+        with self.assertRaises(ValidationError,
+                               msg="create transaction with negative amounts results in errors") as error:
+            create_transaction('meh', self.foreign, self.personal, -50, Transaction.WITHDRAW,
+                               date=date(2018, 1, 1))
+        self.assertIn(TransactionSignValidationError().message, error.exception.messages)
+
+    def test_creating_transactions_requires_positive_amounts_transfer(self):
+        with self.assertRaises(ValidationError,
+                               msg="create transaction with negative amounts results in errors") as error:
+            create_transaction('meh', self.foreign, self.personal, -50, Transaction.TRANSFER,
+                               date=date(2018, 1, 1))
+        self.assertIn(TransactionSignValidationError().message, error.exception.messages)
 
 
 class TransactionModelTests(TestCase):

--- a/silverstrike/tests/test_rest_api.py
+++ b/silverstrike/tests/test_rest_api.py
@@ -1,0 +1,79 @@
+import copy
+from datetime import date
+
+from django.test import TestCase
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework.exceptions import ValidationError as RestValidationError
+
+from silverstrike.models import Account, Transaction
+from silverstrike.models.errors import TransactionSplitSumValidationError
+from silverstrike.rest.serializers import TransactionSerializer
+
+
+def create_split(title, src, dst, amount, date=date.today(), category=None):
+    return {"title": title,
+            "account": src,
+            "opposing_account": dst,
+            "amount": amount,
+            "date": date.today(),
+            "category": category
+            }
+
+
+def create_rest_transaction_with_splits(title, src, dst, amount, type, splits, date=date.today()):
+    serializer = TransactionSerializer()
+    data = {
+        "title": title,
+        "src": src,
+        "dst": dst,
+        "amount": amount,
+        "transaction_type": type,
+        "date": date,
+        "splits": splits
+    }
+    validated = serializer.validate(data)
+    return serializer.create(validated)
+
+
+class RestTests(TestCase):
+    def setUp(self):
+        self.personal = Account.objects.create(name='personal')
+        self.foreign = Account.objects.create(name='foreign')
+
+    def test_rest_validates_required_fields_are_set(self):
+        serializer = TransactionSerializer()
+
+        all_data = {
+            "title": 'meh',
+            "src": self.personal,
+            "dst": self.foreign,
+            "amount": 44.44,
+            "transaction_type": 2,
+            "date": date.today(),
+        }
+        for f in all_data.keys():
+            data = copy.copy(all_data)
+            data.pop(f)
+            with self.assertRaises(RestValidationError):
+                serializer.validate(data)
+
+    def test_split_raises_validation_error_for_unbalanced_sum(self):
+        unbalanced_split = [create_split("meh split 1",
+                                         self.personal,
+                                         self.foreign,
+                                         -50),
+                            create_split("meh split 2",
+                                         self.foreign,
+                                         self.personal,
+                                         60)]
+
+        with self.assertRaises(DjangoValidationError,
+                               msg="create transaction with splits should validate "
+                                   "transaction is in balance") as error:
+            create_rest_transaction_with_splits('meh', self.foreign, self.personal, -70,
+                                                Transaction.WITHDRAW,
+                                                unbalanced_split)
+        assert TransactionSplitSumValidationError(self.personal).message in error.exception.messages
+
+    def test_transaction_serialization_saves(self):
+        pass

--- a/silverstrike/tests/views/test_IndexView.py
+++ b/silverstrike/tests/views/test_IndexView.py
@@ -48,7 +48,7 @@ class IndexViewTestCase(TestCase):
     def test_balance_does_not_count_non_dashboard_accounts(self):
         create_transaction('meh', self.foreign, self.account, 1000,
                            Transaction.DEPOSIT, date(2015, 1, 1))
-        create_transaction('meh', self.cash, self.foreign, 500,
+        create_transaction('meh', self.foreign, self.cash, 500,
                            Transaction.DEPOSIT, date(2015, 1, 1))
         context = self.client.get(reverse('index')).context
         self.assertEqual(context['balance'], 1000)


### PR DESCRIPTION
The goal here is to resolve #144, and ensure that there's some general validation on all transaction creation, regardless of api/import/ui creation. This will expose the following errors on transaction creation

* deposit transaction accounts have src type of Foreign, dst type of Personal
* withdraw transaction accounts have src type of Personal dst type of Foreign
* transfer transaction accounts have src and dst of Personal
* amounts on the source transaction are equal to the amounts specified in the splits
* amounts in each of the accounts specified in splits add up to 0
* saving transactions with negative amounts is not allowed

This last one is special; adding this as a condition means the firefly import tests fail. Is that expected? Should that be fixed in the firefly import tests, or in the firefly import code (as in, it might be choosing the wrong transaction type), or is that a special case that should be allowed?